### PR TITLE
remove USER node.

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         dockerfile: 10/vanilla
         image-name: node
-        tags: 10 10.22 10.22.1 10.22.1-stretch
+        tags: 10 10.22 10.22.1 10.22.1-stretch-2
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: '${{ secrets.DOCKER_PASSWORD }}'
@@ -30,7 +30,7 @@ jobs:
       with:
         dockerfile: 10/java
         image-name: node
-        tags: 10-java 10.22-java 10.22.1-java 10.22.1-stretch-java
+        tags: 10-java 10.22-java 10.22.1-java 10.22.1-stretch-java-2
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: '${{ secrets.DOCKER_PASSWORD }}'
@@ -47,7 +47,7 @@ jobs:
       with:
         dockerfile: lts/vanilla
         image-name: node
-        tags: lts 12 12.18 12.18.4 12.18.4-stretch
+        tags: lts 12 12.18 12.18.4 12.18.4-stretch-2
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: '${{ secrets.DOCKER_PASSWORD }}'
@@ -64,7 +64,7 @@ jobs:
       with:
         dockerfile: lts/java
         image-name: node
-        tags: lts-java 12-java 12.18-java 12.18.4-java 12.18.4-stretch-java
+        tags: lts-java 12-java 12.18-java 12.18.4-java 12.18.4-stretch-java-2
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: '${{ secrets.DOCKER_PASSWORD }}'
@@ -81,7 +81,7 @@ jobs:
       with:
         dockerfile: stable/vanilla
         image-name: node
-        tags: latest stable 14 14.13 14.13.1 14.13.1-stretch
+        tags: latest stable 14 14.13 14.13.1 14.13.1-stretch-2
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: '${{ secrets.DOCKER_PASSWORD }}'
@@ -98,7 +98,7 @@ jobs:
       with:
         dockerfile: stable/java
         image-name: node
-        tags: java stable-java 14-java 14.13-java 14.13.1-java 14.13.1-stretch-java
+        tags: java stable-java 14-java 14.13-java 14.13.1-java 14.13.1-stretch-java-2
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: '${{ secrets.DOCKER_PASSWORD }}'

--- a/10/java/Dockerfile
+++ b/10/java/Dockerfile
@@ -16,8 +16,6 @@ RUN apt-get update && \
 RUN mkdir /app
 RUN chown node:node /app
 
-USER node
-
 WORKDIR /app
 
 ADD REPO .

--- a/10/vanilla/Dockerfile
+++ b/10/vanilla/Dockerfile
@@ -15,8 +15,6 @@ RUN apt-get update && \
 RUN mkdir /app
 RUN chown node:node /app
 
-USER node
-
 WORKDIR /app
 
 ADD REPO .

--- a/12/java/Dockerfile
+++ b/12/java/Dockerfile
@@ -16,8 +16,6 @@ RUN apt-get update && \
 RUN mkdir /app
 RUN chown node:node /app
 
-USER node
-
 WORKDIR /app
 
 ADD REPO .

--- a/12/vanilla/Dockerfile
+++ b/12/vanilla/Dockerfile
@@ -15,8 +15,6 @@ RUN apt-get update && \
 RUN mkdir /app
 RUN chown node:node /app
 
-USER node
-
 WORKDIR /app
 
 ADD REPO .

--- a/14/java/Dockerfile
+++ b/14/java/Dockerfile
@@ -16,8 +16,6 @@ RUN apt-get update && \
 RUN mkdir /app
 RUN chown node:node /app
 
-USER node
-
 WORKDIR /app
 
 ADD REPO .

--- a/14/vanilla/Dockerfile
+++ b/14/vanilla/Dockerfile
@@ -15,8 +15,6 @@ RUN apt-get update && \
 RUN mkdir /app
 RUN chown node:node /app
 
-USER node
-
 WORKDIR /app
 
 ADD REPO .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project uses the version of main tool as main version number .
 
 ### Changed
+- Remove USER node. GitHub actions requires root in order to do a checkout.
 - Update version to 14.13.1-stretch
 - Update version to 14.13.0-stretch
 - Update version to 14.12.0-stretch


### PR DESCRIPTION
Remove USER: `node` from the docker images. Docker-images should use user `root`.

# Reason
When you're using a docker image with a non-root user, you cannot checkout the code.

See:
workflow: https://github.com/JeroenKnoops/test-philips-node-image/blob/e53278512a9ff4680c2f364792ac10d1a04c99ae/.github/workflows/env.yml
result: https://github.com/JeroenKnoops/test-philips-node-image/actions/runs/310224232

# FAQ
## Where can I find the old image with USER: `node`?
I've appended the most specific version with `-2` so the old version is still available.
