### PR TITLE
Add lerna

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -98,7 +98,8 @@ jobs:
       with:
         dockerfile: stable/java
         image-name: node
-        tags: java stable-java 14-java 14.13-java 14.13.1-java 14.13.1-stretch-java-2
+        tags: 14-java-lerna
+        push-branches: add-lerna
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: '${{ secrets.DOCKER_PASSWORD }}'

--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -98,8 +98,7 @@ jobs:
       with:
         dockerfile: stable/java
         image-name: node
-        tags: 14-java-lerna
-        push-branches: add-lerna
+        tags: java stable-java 14-java 14.13-java 14.13.1-java 14.13.1-stretch-java-2
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: '${{ secrets.DOCKER_PASSWORD }}'

--- a/12/java/Dockerfile
+++ b/12/java/Dockerfile
@@ -16,6 +16,8 @@ RUN apt-get update && \
 RUN mkdir /app
 RUN chown node:node /app
 
+RUN yarn global add lerna
+
 WORKDIR /app
 
 ADD REPO .

--- a/12/vanilla/Dockerfile
+++ b/12/vanilla/Dockerfile
@@ -15,6 +15,8 @@ RUN apt-get update && \
 RUN mkdir /app
 RUN chown node:node /app
 
+RUN yarn global add lerna
+
 WORKDIR /app
 
 ADD REPO .

--- a/14/java/Dockerfile
+++ b/14/java/Dockerfile
@@ -16,6 +16,8 @@ RUN apt-get update && \
 RUN mkdir /app
 RUN chown node:node /app
 
+RUN yarn global add lerna
+
 WORKDIR /app
 
 ADD REPO .

--- a/14/vanilla/Dockerfile
+++ b/14/vanilla/Dockerfile
@@ -15,6 +15,8 @@ RUN apt-get update && \
 RUN mkdir /app
 RUN chown node:node /app
 
+RUN yarn global add lerna
+
 WORKDIR /app
 
 ADD REPO .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project uses the version of main tool as main version number .
 
 ### Changed
+- Add lerna
 - Remove USER node. GitHub actions requires root in order to do a checkout.
 - Update version to 14.13.1-stretch
 - Update version to 14.13.0-stretch


### PR DESCRIPTION
In modern development, we often use `lerna`.

We want this installed globally, therefor adding this into our base image seems right.