### PR TITLE
Replace deprecated MAINTAINER instruction with LABEL

### DIFF
--- a/14/java/Dockerfile
+++ b/14/java/Dockerfile
@@ -1,5 +1,5 @@
 FROM node:14.15.3-stretch
-MAINTAINER Forest Keepers <Jeroen.knoops@philips.com>
+LABEL maintainer="Forest Keepers <Jeroen.knoops@philips.com>"
 
 RUN apt-get update && \
     apt-get install -y \

--- a/14/vanilla/Dockerfile
+++ b/14/vanilla/Dockerfile
@@ -1,5 +1,5 @@
 FROM node:14.15.3-stretch
-MAINTAINER Forest Keepers <Jeroen.knoops@philips.com>
+LABEL maintainer="Forest Keepers <Jeroen.knoops@philips.com>"
 
 RUN apt-get update && \
     apt-get install -y \


### PR DESCRIPTION
https://docs.docker.com/engine/reference/builder/#maintainer-deprecated

The other Dockerfiles are already on par.