### PR TITLE
Upgrade base images to latest buster versions

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -19,7 +19,7 @@ jobs:
       with:
         dockerfile: 12/vanilla
         image-name: node
-        tags: 12 12.20 12.20.0 12.20.0-stretch
+        tags: 12 12.20 12.20.0 12.20.0-buster
         push-branches: main
   
   build_node_12_java:
@@ -32,7 +32,7 @@ jobs:
       with:
         dockerfile: 12/java
         image-name: node
-        tags: 12-java 12.20-java 12.20.0-java 12.20.0-stretch-java
+        tags: 12-java 12.20-java 12.20.0-java 12.20.0-buster-slim-java
         push-branches: main
 
   build_node_lts:
@@ -45,7 +45,7 @@ jobs:
       with:
         dockerfile: lts/vanilla
         image-name: node
-        tags: lts 14 14.15 14.15.3 14.15.3-stretch
+        tags: lts 14 14.15 14.15.4 14.15.4-buster
         push-branches: main
 
   build_node_lts_java:
@@ -58,7 +58,7 @@ jobs:
       with:
         dockerfile: lts/java
         image-name: node
-        tags: lts-java 14-java 14.15-java 14.15.3-java 14.15.3-stretch-java
+        tags: lts-java 14-java 14.15-java 14.15.4-java 14.15.4-buster-slim-java
         push-branches: main
 
   build_node_stable:
@@ -71,7 +71,7 @@ jobs:
       with:
         dockerfile: stable/vanilla
         image-name: node
-        tags: latest stable 15 15.3 15.3.0 15.3.0-stretch
+        tags: latest stable 15 15.5 15.5.1 15.5.1-buster
         push-branches: main
 
   build_node_stable_java:
@@ -84,5 +84,5 @@ jobs:
       with:
         dockerfile: stable/java
         image-name: node
-        tags: java stable-java 15-java 15.3-java 15.3.0-java 15.3.0-stretch-java
+        tags: java stable-java 15-java 15.5-java 15.5.1-java 15.5.1-buster-java
         push-branches: main

--- a/12/java/Dockerfile
+++ b/12/java/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.20.0-stretch
+FROM node:12.20.0-buster-slim
 LABEL maintainer="Forest Keepers <Jeroen.knoops@philips.com>"
 
 RUN apt-get update && \

--- a/12/java/Dockerfile
+++ b/12/java/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.20.0-buster-slim
+FROM node:12.20.0-buster
 LABEL maintainer="Forest Keepers <Jeroen.knoops@philips.com>"
 
 RUN apt-get update && \

--- a/12/vanilla/Dockerfile
+++ b/12/vanilla/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.20.0-stretch
+FROM node:12.20.0-buster-slim
 LABEL maintainer="Forest Keepers <Jeroen.knoops@philips.com>"
 
 RUN apt-get update && \

--- a/14/java/Dockerfile
+++ b/14/java/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.15.4-buster-slim
+FROM node:14.15.4-buster
 LABEL maintainer="Forest Keepers <Jeroen.knoops@philips.com>"
 
 RUN apt-get update && \

--- a/14/java/Dockerfile
+++ b/14/java/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.15.3-stretch
+FROM node:14.15.4-buster-slim
 LABEL maintainer="Forest Keepers <Jeroen.knoops@philips.com>"
 
 RUN apt-get update && \

--- a/14/vanilla/Dockerfile
+++ b/14/vanilla/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.15.3-stretch
+FROM node:14.15.4-buster-slim
 LABEL maintainer="Forest Keepers <Jeroen.knoops@philips.com>"
 
 RUN apt-get update && \

--- a/15/java/Dockerfile
+++ b/15/java/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:15.3.0-stretch
+FROM node:15.5.1-buster-slim
 LABEL maintainer="Forest Keepers <Jeroen.knoops@philips.com>"
 
 RUN apt-get update && \

--- a/15/java/Dockerfile
+++ b/15/java/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:15.5.1-buster-slim
+FROM node:15.5.1-buster
 LABEL maintainer="Forest Keepers <Jeroen.knoops@philips.com>"
 
 RUN apt-get update && \

--- a/15/vanilla/Dockerfile
+++ b/15/vanilla/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:15.3.0-stretch
+FROM node:15.5.1-buster-slim
 LABEL maintainer="Forest Keepers <Jeroen.knoops@philips.com>"
 
 RUN apt-get update && \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project uses the version of main tool as main version number .
 
 ### Changed
+- Use buster in stead of stretch
 - lts --> 14.15.3
 - lts --> 14.15.2
 - lts --> 14.15.0

--- a/README.md
+++ b/README.md
@@ -63,22 +63,22 @@ You can use this to pin down a version of the container from an existing develop
 ## Simple Tags
 
 ### nodeJS stable
-- `node` `node:stable` `node:15` `node:15.3` `node:15.3.0` `node:15.3.0-stretch` [15/vanilla/Dockerfile](15/vanilla/Dockerfile)
+- `node` `node:stable` `node:15` `node:15.3` `node:15.3.1` `node:15.3.0-buster` [15/vanilla/Dockerfile](15/vanilla/Dockerfile)
 
 ### nodeJS lts
-- `node:lts` `node:14` `node:14.15` `node:14.15.3` `node:14.15.3-stretch` [14/vanilla/Dockerfile](14/vanilla/Dockerfile)
+- `node:lts` `node:14` `node:14.15` `node:14.15.4` `node:14.15.4-buster` [14/vanilla/Dockerfile](14/vanilla/Dockerfile)
 
 ### nodeJS 12
-- `node:12` `node:12.20` `node:12.20.0` `node:12.20.0-stretch` [10/vanilla/Dockerfile](10/vanilla/Dockerfile)
+- `node:12` `node:12.20` `node:12.20.0` `node:12.20.0-buster-slim` [10/vanilla/Dockerfile](10/vanilla/Dockerfile)
 
 ### nodeJS stable with openjdk
-- `node:java` `node:stable-java` `node:15-java` `node:15.3-java` `node:15.3.0-java` `node:15.3.0-stretch-java` [15/java/Dockerfile](15/java/Dockerfile)`
+- `node:java` `node:stable-java` `node:15-java` `node:15.3-java` `node:15.3.1-java` `node:15.3.0-buster-java` [15/java/Dockerfile](15/java/Dockerfile)`
 
 ### nodeJS lts with openjdk
-- `node:lts-java` `node:14-java` `node:14.15-java` `node:14.15.3-java` `node:14.15.3-stretch-java` [14/java/Dockerfile](14/java/Dockerfile)
+- `node:lts-java` `node:14-java` `node:14.15-java` `node:14.15.4-java` `node:14.15.4-buster-slim-java` [14/java/Dockerfile](14/java/Dockerfile)
 
 ### nodeJS 12 with openjdk
-- `node:12-java` `node:12.20-java` `node:12.20.0-java` `node:12.20.0-stretch-java` [12/java/Dockerfile](12/java/Dockerfile)
+- `node:12-java` `node:12.20-java` `node:12.20.0-java` `node:12.20.0-buster-slim-java` [12/java/Dockerfile](12/java/Dockerfile)
         
 
 ## Why


### PR DESCRIPTION
resolves #76 

- By upgrading to `buster` we have newer versions of software available in apt.
- Picked the `buster-slim` versions to reduce image sizes.
- For the java variants we have to stick with the full version of `buster` due to install errors of Java, didn't try to resolve them to be able to use slim version. Might be something for a separate PR.

This PR also updates to the latest patch and minor versions.