### PR TITLE
Update to versions: v14.19.3 / v16.15.1 (LTS / stable / active) / v18.3.0 (current / latest)

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -26,33 +26,33 @@ jobs:
 
           - name: Build node lts stable
             dockerfile: lts/vanilla
-            tags: stable lts 16 16.15 16.15.0 16.15.0-buster
+            tags: stable lts 16 16.15 16.15.1 16.15.1-buster
           - name: Build node lts stable yarn 2
             dockerfile: lts/yarn2
-            tags: stable-yarn2 lts-yarn2 16-yarn2 16.15-yarn2 16.15.0-yarn2 16.15.0-buster-yarn2
+            tags: stable-yarn2 lts-yarn2 16-yarn2 16.15-yarn2 16.15.1-yarn2 16.15.1-buster-yarn2
           - name: Build node lts stable java
             dockerfile: lts/java
-            tags: stable-java lts-java 16-java 16.15-java 16.15.0-java 16.15.0-buster-java
+            tags: stable-java lts-java 16-java 16.15-java 16.15.1-java 16.15.1-buster-java
 
           - name: Build node 17
             dockerfile: 17/vanilla
-            tags: 17 17.9 17.9.0 17.9.0-buster
+            tags: 17 17.9 17.9.1 17.9.1-buster
           - name: Build node 17 with yarn 2
             dockerfile: 17/yarn2
-            tags: 17-yarn2 17.9-yarn2 17.9.0-yarn2 17.9.0-buster-yarn2
+            tags: 17-yarn2 17.9-yarn2 17.9.1-yarn2 17.9.1-buster-yarn2
           - name: Build node 17 with java
             dockerfile: 17/java
-            tags: 17-java 17.9-java 17.9.0-java 17.9.0-buster-java
+            tags: 17-java 17.9-java 17.9.1-java 17.9.1-buster-java
 
           - name: Build node 18
             dockerfile: current/vanilla
-            tags: latest current 18 18.2 18.2.0 18.2.0-buster
+            tags: latest current 18 18.3 18.3.0 18.3.0-buster
           - name: Build node 18 with yarn 2
             dockerfile: current/yarn2
-            tags: yarn2 current-yarn2 18-yarn2 18.2-yarn2 18.2.0-yarn2 18.2.0-buster-yarn2
+            tags: yarn2 current-yarn2 18-yarn2 18.3-yarn2 18.3.0-yarn2 18.3.0-buster-yarn2
           - name: Build node 18 with java
             dockerfile: current/java
-            tags: java current-java 18-java 18.2-java 18.2.0-java 18.2.0-buster-java
+            tags: java current-java 18-java 18.3-java 18.3.0-java 18.3.0-buster-java
     steps:
       - uses: actions/checkout@v3
       - name: ${{ matrix.name }}

--- a/16/java/Dockerfile
+++ b/16/java/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.15.0-buster
+FROM node:16.15.1-buster
 LABEL maintainer="Forest Keepers <Jeroen.knoops@philips.com>"
 
 RUN apt-get update && \

--- a/16/vanilla/Dockerfile
+++ b/16/vanilla/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.15.0-buster-slim
+FROM node:16.15.1-buster-slim
 LABEL maintainer="Forest Keepers <Jeroen.knoops@philips.com>"
 
 RUN apt-get update && \

--- a/16/yarn2/Dockerfile
+++ b/16/yarn2/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.15.0-buster-slim
+FROM node:16.15.1-buster-slim
 LABEL maintainer="Forest Keepers <Jeroen.knoops@philips.com>"
 
 RUN apt-get update && \

--- a/17/java/Dockerfile
+++ b/17/java/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:17.9.0-buster
+FROM node:17.9.1-buster
 LABEL maintainer="Forest Keepers <Jeroen.knoops@philips.com>"
 
 RUN apt-get update && \

--- a/17/vanilla/Dockerfile
+++ b/17/vanilla/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:17.9.0-buster-slim
+FROM node:17.9.1-buster-slim
 LABEL maintainer="Forest Keepers <Jeroen.knoops@philips.com>"
 
 RUN apt-get update && \

--- a/17/yarn2/Dockerfile
+++ b/17/yarn2/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:17.9.0-buster-slim
+FROM node:17.9.1-buster-slim
 LABEL maintainer="Forest Keepers <Jeroen.knoops@philips.com>"
 
 RUN apt-get update && \

--- a/18/java/Dockerfile
+++ b/18/java/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.2.0-buster
+FROM node:18.3.0-buster
 LABEL maintainer="Forest Keepers <Jeroen.knoops@philips.com>"
 
 RUN apt-get update && \

--- a/18/vanilla/Dockerfile
+++ b/18/vanilla/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.2.0-buster-slim
+FROM node:18.3.0-buster-slim
 LABEL maintainer="Forest Keepers <Jeroen.knoops@philips.com>"
 
 RUN apt-get update && \

--- a/18/yarn2/Dockerfile
+++ b/18/yarn2/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.2.0-buster-slim
+FROM node:18.3.0-buster-slim
 LABEL maintainer="Forest Keepers <Jeroen.knoops@philips.com>"
 
 RUN apt-get update && \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project uses the version of main tool as main version number .
 
 ### Changed
+- v14.19.3 / v16.15.1 (LTS / stable / active) / v18.3.0 (current / latest)
 - v14.19.3 / v16.15.0 (LTS / stable / active) / v18.2.0 (current / latest)
 - v14.19.1 / v16.15.0 (LTS / stable / active) / v18.1.0 (current)
 - v14.19.1 / v16.15.0 (LTS / stable / active) / v18.0.0 (current)

--- a/README.md
+++ b/README.md
@@ -72,32 +72,32 @@ $ docker run -it philipssoftware/node:18
 ## Simple Tags
 
 ### nodeJS current
-- `node:current` `node:latest` `node:18` `node:18.2` `node:18.2.0` `node:18.2.0-buster` [current/vanilla/Dockerfile](current/vanilla/Dockerfile)
+- `node:current` `node:latest` `node:18` `node:18.3` `node:18.3.0` `node:18.3.0-buster` [current/vanilla/Dockerfile](current/vanilla/Dockerfile)
 
 ### nodeJS lts / stable
-- `node:stable` `node:lts` `node:16` `node:16.15` `node:16.15.0` `node:16.15.0-buster` [lts/vanilla/Dockerfile](lts/vanilla/Dockerfile)
+- `node:stable` `node:lts` `node:16` `node:16.15` `node:16.15.1` `node:16.15.1-buster` [lts/vanilla/Dockerfile](lts/vanilla/Dockerfile)
 
 ### nodeJS 14 - not recommended (use `stable` or `lts`)
 - `node:14` `node:14.19` `node:14.19.3` `node:14.19.3-buster-slim` [14/vanilla/Dockerfile](14/vanilla/Dockerfile)
 
 ### nodeJS 17 - not recommended (use `stable` or `lts`)
-- `node:17` `node:17.9` `node:17.9.0` `node:17.9.0-buster` [current/vanilla/Dockerfile](current/vanilla/Dockerfile)
+- `node:17` `node:17.9` `node:17.9.1` `node:17.9.1-buster` [current/vanilla/Dockerfile](current/vanilla/Dockerfile)
 
 ## Tags with yarn2
 
 ### nodeJS current - Yarn 2
--  `node:latest-yarn2` `node:current-yarn2` `node:18-yarn2` `node:18.2-yarn2` `node:18.2.0-yarn2` `node:18.2.0-buster-yarn2` [current/yarn2/Dockerfile](current/yarn2/Dockerfile)
+-  `node:latest-yarn2` `node:current-yarn2` `node:18-yarn2` `node:18.3-yarn2` `node:18.3.0-yarn2` `node:18.3.0-buster-yarn2` [current/yarn2/Dockerfile](current/yarn2/Dockerfile)
 
 ### nodeJS lts / stable - Yarn 2
-- `node:yarn2` `node:stable-yarn2` `node:lts-yarn2` `node:16-yarn2` `node:16.15-yarn2` `node:16.15.0-yarn2` `node:16.15.0-buster-yarn2` [lts/yarn2/Dockerfile](lts/yarn2/Dockerfile)
+- `node:yarn2` `node:stable-yarn2` `node:lts-yarn2` `node:16-yarn2` `node:16.15-yarn2` `node:16.15.1-yarn2` `node:16.15.1-buster-yarn2` [lts/yarn2/Dockerfile](lts/yarn2/Dockerfile)
 
 ## Tags with openjdk
 
 ### nodeJS lts / stable with openjdk
-- `node:java` `node:stable-java` `node:lts-java` `node:16-java` `node:16.15-java` `node:16.15.0-java` `node:16.15.0-buster-java` [lts/java/Dockerfile](lts/java/Dockerfile)`
+- `node:java` `node:stable-java` `node:lts-java` `node:16-java` `node:16.15-java` `node:16.15.1-java` `node:16.15.1-buster-java` [lts/java/Dockerfile](lts/java/Dockerfile)`
 
 ### nodeJS current with openjdk
-- `node:current-java` `node:17-java` `node:17.9-java` `node:17.9.0-java` `node:17.9.0-buster-java` [current/java/Dockerfile](current/java/Dockerfile)`
+- `node:current-java` `node:17-java` `node:17.9-java` `node:17.9.1-java` `node:17.9.1-buster-java` [current/java/Dockerfile](current/java/Dockerfile)`
 
 ### nodeJS 14 with openjdk - not recommended (use `stable` or `lts`)
 - `node:14-java` `node:14.19-java` `node:14.19.3-java` `node:14.19.3-buster-slim-java` [14/java/Dockerfile](14/java/Dockerfile)


### PR DESCRIPTION
Update to latest versions.

## Supported versions
v14.19.3 / v16.15.1 (LTS / stable / active) / v18.3.0 (current / latest)

## Legacy versions
v17.9.1