### PR TITLE
Update versions to v14.20.0 / v16.16.0 / v18.7.0

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -19,20 +19,20 @@ jobs:
         include:
           - name: Build node 14
             dockerfile: 14/vanilla
-            tags: 14 14.19 14.19.3 14.19.3-buster
+            tags: 14 14.20 14.20.0 14.20.0-buster
           - name: Build node 14 with java
             dockerfile: 14/java
-            tags: 14-java 14.19-java 14.19.3-java 14.19.3-buster-slim-java
+            tags: 14-java 14.20-java 14.20.0-java 14.20.0-buster-slim-java
 
           - name: Build node lts stable
             dockerfile: lts/vanilla
-            tags: stable lts 16 16.15 16.15.1 16.15.1-buster
+            tags: stable lts 16 16.16 16.16.0 16.16.0-buster
           - name: Build node lts stable yarn 2
             dockerfile: lts/yarn2
-            tags: stable-yarn2 lts-yarn2 16-yarn2 16.15-yarn2 16.15.1-yarn2 16.15.1-buster-yarn2
+            tags: stable-yarn2 lts-yarn2 16-yarn2 16.16-yarn2 16.16.0-yarn2 16.16.0-buster-yarn2
           - name: Build node lts stable java
             dockerfile: lts/java
-            tags: stable-java lts-java 16-java 16.15-java 16.15.1-java 16.15.1-buster-java
+            tags: stable-java lts-java 16-java 16.16-java 16.16.0-java 16.16.0-buster-java
 
           - name: Build node 17
             dockerfile: 17/vanilla
@@ -46,13 +46,13 @@ jobs:
 
           - name: Build node 18
             dockerfile: current/vanilla
-            tags: latest current 18 18.3 18.3.0 18.3.0-buster
+            tags: latest current 18 18.7 18.7.0 18.7.0-buster
           - name: Build node 18 with yarn 2
             dockerfile: current/yarn2
-            tags: yarn2 current-yarn2 18-yarn2 18.3-yarn2 18.3.0-yarn2 18.3.0-buster-yarn2
+            tags: yarn2 current-yarn2 18-yarn2 18.7-yarn2 18.7.0-yarn2 18.7.0-buster-yarn2
           - name: Build node 18 with java
             dockerfile: current/java
-            tags: java current-java 18-java 18.3-java 18.3.0-java 18.3.0-buster-java
+            tags: java current-java 18-java 18.7-java 18.7.0-java 18.7.0-buster-java
     steps:
       - uses: actions/checkout@v3
       - name: ${{ matrix.name }}

--- a/14/java/Dockerfile
+++ b/14/java/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.19.3-buster
+FROM node:14.20.0-buster
 LABEL maintainer="Forest Keepers <Jeroen.knoops@philips.com>"
 
 RUN apt-get update && \

--- a/14/vanilla/Dockerfile
+++ b/14/vanilla/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.19.3-buster-slim
+FROM node:14.20.0-buster-slim
 LABEL maintainer="Forest Keepers <Jeroen.knoops@philips.com>"
 
 RUN apt-get update && \

--- a/16/java/Dockerfile
+++ b/16/java/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.15.1-buster
+FROM node:16.16.0-buster
 LABEL maintainer="Forest Keepers <Jeroen.knoops@philips.com>"
 
 RUN apt-get update && \

--- a/16/vanilla/Dockerfile
+++ b/16/vanilla/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.15.1-buster-slim
+FROM node:16.16.0-buster-slim
 LABEL maintainer="Forest Keepers <Jeroen.knoops@philips.com>"
 
 RUN apt-get update && \

--- a/16/yarn2/Dockerfile
+++ b/16/yarn2/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.15.1-buster-slim
+FROM node:16.16.0-buster-slim
 LABEL maintainer="Forest Keepers <Jeroen.knoops@philips.com>"
 
 RUN apt-get update && \

--- a/18/java/Dockerfile
+++ b/18/java/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.3.0-buster
+FROM node:18.7.0-buster
 LABEL maintainer="Forest Keepers <Jeroen.knoops@philips.com>"
 
 RUN apt-get update && \

--- a/18/vanilla/Dockerfile
+++ b/18/vanilla/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.3.0-buster-slim
+FROM node:18.7.0-buster-slim
 LABEL maintainer="Forest Keepers <Jeroen.knoops@philips.com>"
 
 RUN apt-get update && \

--- a/18/yarn2/Dockerfile
+++ b/18/yarn2/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.3.0-buster-slim
+FROM node:18.7.0-buster-slim
 LABEL maintainer="Forest Keepers <Jeroen.knoops@philips.com>"
 
 RUN apt-get update && \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project uses the version of main tool as main version number .
 
 ### Changed
+- v14.20.0 / v16.16.0 (LTS / stable / active) / v18.7.0 (current / latest)
 - v14.19.3 / v16.15.1 (LTS / stable / active) / v18.3.0 (current / latest)
 - v14.19.3 / v16.15.0 (LTS / stable / active) / v18.2.0 (current / latest)
 - v14.19.1 / v16.15.0 (LTS / stable / active) / v18.1.0 (current)

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ This contains all the similar tags at the point of creation.
 
 ```
 $ docker run philipssoftware/node:14 cat TAGS
-node node:stable node:14 node:14.19.3 node:14.19.3 node:14.19.3-stretch
+node node:stable node:14 node:14.20.0 node:14.20.0 node:14.20.0-stretch
 ```
 
 You can use this to pin down a version of the container from an existing development build for production. When using `node:11` for development. This ensures that you've got all security updates in your build. If you want to pin the version of your image down for production, you can use this file inside of the container to look for the most specific tag, the last one.
@@ -72,13 +72,13 @@ $ docker run -it philipssoftware/node:18
 ## Simple Tags
 
 ### nodeJS current
-- `node:current` `node:latest` `node:18` `node:18.3` `node:18.3.0` `node:18.3.0-buster` [current/vanilla/Dockerfile](current/vanilla/Dockerfile)
+- `node:current` `node:latest` `node:18` `node:18.7` `node:18.7.0` `node:18.7.0-buster` [current/vanilla/Dockerfile](current/vanilla/Dockerfile)
 
 ### nodeJS lts / stable
-- `node:stable` `node:lts` `node:16` `node:16.15` `node:16.15.1` `node:16.15.1-buster` [lts/vanilla/Dockerfile](lts/vanilla/Dockerfile)
+- `node:stable` `node:lts` `node:16` `node:16.16` `node:16.16.0` `node:16.16.0-buster` [lts/vanilla/Dockerfile](lts/vanilla/Dockerfile)
 
 ### nodeJS 14 - not recommended (use `stable` or `lts`)
-- `node:14` `node:14.19` `node:14.19.3` `node:14.19.3-buster-slim` [14/vanilla/Dockerfile](14/vanilla/Dockerfile)
+- `node:14` `node:14.20` `node:14.20.0` `node:14.20.0-buster-slim` [14/vanilla/Dockerfile](14/vanilla/Dockerfile)
 
 ### nodeJS 17 - not recommended (use `stable` or `lts`)
 - `node:17` `node:17.9` `node:17.9.1` `node:17.9.1-buster` [current/vanilla/Dockerfile](current/vanilla/Dockerfile)
@@ -86,21 +86,21 @@ $ docker run -it philipssoftware/node:18
 ## Tags with yarn2
 
 ### nodeJS current - Yarn 2
--  `node:latest-yarn2` `node:current-yarn2` `node:18-yarn2` `node:18.3-yarn2` `node:18.3.0-yarn2` `node:18.3.0-buster-yarn2` [current/yarn2/Dockerfile](current/yarn2/Dockerfile)
+-  `node:latest-yarn2` `node:current-yarn2` `node:18-yarn2` `node:18.7-yarn2` `node:18.7.0-yarn2` `node:18.7.0-buster-yarn2` [current/yarn2/Dockerfile](current/yarn2/Dockerfile)
 
 ### nodeJS lts / stable - Yarn 2
-- `node:yarn2` `node:stable-yarn2` `node:lts-yarn2` `node:16-yarn2` `node:16.15-yarn2` `node:16.15.1-yarn2` `node:16.15.1-buster-yarn2` [lts/yarn2/Dockerfile](lts/yarn2/Dockerfile)
+- `node:yarn2` `node:stable-yarn2` `node:lts-yarn2` `node:16-yarn2` `node:16.16-yarn2` `node:16.16.0-yarn2` `node:16.16.0-buster-yarn2` [lts/yarn2/Dockerfile](lts/yarn2/Dockerfile)
 
 ## Tags with openjdk
 
 ### nodeJS lts / stable with openjdk
-- `node:java` `node:stable-java` `node:lts-java` `node:16-java` `node:16.15-java` `node:16.15.1-java` `node:16.15.1-buster-java` [lts/java/Dockerfile](lts/java/Dockerfile)`
+- `node:java` `node:stable-java` `node:lts-java` `node:16-java` `node:16.16-java` `node:16.16.0-java` `node:16.16.0-buster-java` [lts/java/Dockerfile](lts/java/Dockerfile)`
 
 ### nodeJS current with openjdk
 - `node:current-java` `node:17-java` `node:17.9-java` `node:17.9.1-java` `node:17.9.1-buster-java` [current/java/Dockerfile](current/java/Dockerfile)`
 
 ### nodeJS 14 with openjdk - not recommended (use `stable` or `lts`)
-- `node:14-java` `node:14.19-java` `node:14.19.3-java` `node:14.19.3-buster-slim-java` [14/java/Dockerfile](14/java/Dockerfile)
+- `node:14-java` `node:14.20-java` `node:14.20.0-java` `node:14.20.0-buster-slim-java` [14/java/Dockerfile](14/java/Dockerfile)
 
 ## Why
 


### PR DESCRIPTION
Node versions:

v14.20.0 / v16.16.0 (LTS / stable / active) / v18.7.0 (current / latest)